### PR TITLE
chore(ci): fix version in the name of release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Package Release Asset
         run: |
-          VERSION="5.1.0"
+          VERSION="5.1.1"
           HASH="${{ steps.vars.outputs.sha_short }}"
           DATE="${{ steps.vars.outputs.build_date }}"
           ASSET_NAME="blender-$VERSION-npr-port-linux64-$HASH-$DATE"
@@ -115,7 +115,7 @@ jobs:
 
       - name: Package Release Asset
         run: |
-          VERSION="5.1.0"
+          VERSION="5.1.1"
           HASH="${{ steps.vars.outputs.sha_short }}"
           DATE="${{ steps.vars.outputs.build_date }}"
           ASSET_NAME="blender-$VERSION-npr-port-macos-$HASH-$DATE"


### PR DESCRIPTION
修正 Linux 和 macOS 构建产物名字中的版本号为 5.1.1