### PR TITLE
ci: use Rocky Linux 9 for Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,66 +7,70 @@ jobs:
   build-linux:
     name: Build Linux x64
     runs-on: ubuntu-24.04
+    container:
+      image: rockylinux/rockylinux:9
     permissions:
       contents: read
+    env:
+      BUILD_CMAKE_ARGS: -DSYCL_CPP_FLAGS=--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr
     steps:
+      - name: Install Dependencies
+        run: |
+          dnf -y update
+          dnf -y install dnf-plugins-core
+          dnf config-manager --set-enabled crb
+          dnf -y install \
+            gcc-toolset-14 \
+            make cmake ninja-build git git-lfs python3 rsync patch subversion tar xz wget \
+            libSM libSM-devel libICE libICE-devel \
+            libX11-devel libXxf86vm libXcursor-devel libXi-devel libXrandr-devel libXinerama-devel \
+            libglvnd-devel mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel \
+            libXext-devel libXrender-devel libXfixes-devel \
+            wayland-devel wayland-protocols-devel libxkbcommon-devel dbus-devel
+
+      - name: Enable GCC Toolset
+        run: |
+          echo "PATH=/opt/rh/gcc-toolset-14/root/usr/bin:/opt/rh/gcc-toolset-14/root/usr/sbin:$PATH" >> "$GITHUB_ENV"
+          echo "CC=gcc" >> "$GITHUB_ENV"
+          echo "CXX=g++" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v6
         with:
+          path: blender
           persist-credentials: false
 
       - name: Get Short Hash & Date
+        working-directory: blender
         id: vars
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "build_date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
-      - name: Install Dependencies
-        run: |
-          retry() {
-            local attempts=5
-            local delay=20
-            local n=1
-            until "$@"; do
-              if [ "$n" -ge "$attempts" ]; then
-                echo "Command failed after $attempts attempts: $*" >&2
-                return 1
-              fi
-              echo "Command failed, retrying in ${delay}s ($n/$attempts): $*" >&2
-              sleep "$delay"
-              n=$((n + 1))
-              delay=$((delay * 2))
-            done
-          }
-
-          retry sudo apt-get update
-          retry sudo apt-get install -y build-essential subversion libx11-dev libxxf86vm-dev libxcursor-dev libxi-dev libxrandr-dev libxinerama-dev libegl-dev
-          retry sudo apt-get install -y libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev linux-libc-dev
-
-          gcc-14 --version
-          g++-14 --version
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-
       - name: Setup Git LFS
+        working-directory: blender
         run: |
           git config lfs.url "https://projects.blender.org/blender/blender.git/info/lfs"
           git config lfs.remote.searchall false
           git lfs install
 
       - name: Blender Make Update
+        working-directory: blender
         run: make update
 
       - name: Download Extra Assets
+        working-directory: blender
         run: |
           curl -L -o release/datafiles/splash.png https://github.com/bb-yi/blender/raw/refs/heads/npr-port-5.1/release/datafiles/splash.png
           curl -L -o assets/nodes/npr_node_groups.blend https://github.com/bb-yi/blender/raw/refs/heads/npr-port-5.1/assets/nodes/npr_node_groups.blend
 
       - name: Build Blender Release
+        working-directory: blender
         run: make release ninja
 
       - name: Package Release Asset
+        working-directory: blender
         run: |
-          VERSION="5.1.0"
+          VERSION="5.1.1"
           HASH="${{ steps.vars.outputs.sha_short }}"
           DATE="${{ steps.vars.outputs.build_date }}"
           ASSET_NAME="blender-$VERSION-npr-port-linux64-$HASH-$DATE"
@@ -83,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-asset
-          path: ${{ env.TAR_PATH }}
+          path: blender/${{ env.TAR_PATH }}
 
   build-macos:
     name: Build macOS
@@ -120,7 +124,7 @@ jobs:
 
       - name: Package Release Asset
         run: |
-          VERSION="5.1.0"
+          VERSION="5.1.1"
           HASH="${{ steps.vars.outputs.sha_short }}"
           DATE="${{ steps.vars.outputs.build_date }}"
           ASSET_NAME="blender-$VERSION-npr-port-macos-$HASH-$DATE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,66 +14,70 @@ jobs:
   build-linux:
     name: Build Linux x64
     runs-on: ubuntu-24.04
+    container:
+      image: rockylinux/rockylinux:9
     permissions:
       contents: read
       actions: write
+    env:
+      BUILD_CMAKE_ARGS: -DSYCL_CPP_FLAGS=--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr
     steps:
+      - name: Install Dependencies
+        run: |
+          dnf -y update
+          dnf -y install dnf-plugins-core
+          dnf config-manager --set-enabled crb
+          dnf -y install \
+            gcc-toolset-14 \
+            make cmake ninja-build git git-lfs python3 rsync patch subversion tar xz wget \
+            libSM libSM-devel libICE libICE-devel \
+            libX11-devel libXxf86vm libXcursor-devel libXi-devel libXrandr-devel libXinerama-devel \
+            libglvnd-devel mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel \
+            libXext-devel libXrender-devel libXfixes-devel \
+            wayland-devel wayland-protocols-devel libxkbcommon-devel dbus-devel
+
+      - name: Enable GCC Toolset
+        run: |
+          echo "PATH=/opt/rh/gcc-toolset-14/root/usr/bin:/opt/rh/gcc-toolset-14/root/usr/sbin:$PATH" >> "$GITHUB_ENV"
+          echo "CC=gcc" >> "$GITHUB_ENV"
+          echo "CXX=g++" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          path: blender
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag_name }}
 
       - name: Get Short Hash & Date
+        working-directory: blender
         id: vars
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "build_date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
-      - name: Install Dependencies
-        run: |
-          retry() {
-            local attempts=5
-            local delay=20
-            local n=1
-            until "$@"; do
-              if [ "$n" -ge "$attempts" ]; then
-                echo "Command failed after $attempts attempts: $*" >&2
-                return 1
-              fi
-              echo "Command failed, retrying in ${delay}s ($n/$attempts): $*" >&2
-              sleep "$delay"
-              n=$((n + 1))
-              delay=$((delay * 2))
-            done
-          }
-
-          retry sudo apt-get update
-          retry sudo apt-get install -y build-essential subversion libx11-dev libxxf86vm-dev libxcursor-dev libxi-dev libxrandr-dev libxinerama-dev libegl-dev
-          retry sudo apt-get install -y libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev linux-libc-dev
-
-          gcc-14 --version
-          g++-14 --version
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-
       - name: Setup Git LFS
+        working-directory: blender
         run: |
           git config lfs.url "https://projects.blender.org/blender/blender.git/info/lfs"
           git config lfs.remote.searchall false
           git lfs install
 
       - name: Blender Make Update
+        working-directory: blender
         run: make update
 
       - name: Download Extra Assets
+        working-directory: blender
         run: |
           curl -L -o release/datafiles/splash.png https://github.com/bb-yi/blender/raw/refs/heads/npr-port-5.1/release/datafiles/splash.png
           curl -L -o assets/nodes/npr_node_groups.blend https://github.com/bb-yi/blender/raw/refs/heads/npr-port-5.1/assets/nodes/npr_node_groups.blend
 
       - name: Build Blender Release
+        working-directory: blender
         run: make release ninja
 
       - name: Package Release Asset
+        working-directory: blender
         run: |
           VERSION="5.1.1"
           HASH="${{ steps.vars.outputs.sha_short }}"
@@ -92,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-asset
-          path: ${{ env.TAR_PATH }}
+          path: blender/${{ env.TAR_PATH }}
 
   build-macos:
     name: Build macOS


### PR DESCRIPTION
launchpad ppa 疑似被 DDoS 炸了，用 ubuntu 22.04 保持兼容性的话，就没法从 ppa 安装 gcc 14，干脆直接换成和官方一样的 Rocky Linux

Rocky Linux 9 使用 glibc 2.34，能兼容包括 ubuntu 22.04 在内的发行版