### PR TITLE
Fix node group asset import overrides

### DIFF
--- a/source/blender/editors/space_node/link_drag_search.cc
+++ b/source/blender/editors/space_node/link_drag_search.cc
@@ -6,7 +6,6 @@
 #include "AS_asset_representation.hh"
 
 #include "BLI_listbase.h"
-#include "BLI_string.h"
 #include "BLI_string_utf8.h"
 
 #include "DNA_space_types.h"
@@ -46,12 +45,6 @@ namespace blender {
 using nodes::SocketLinkOperation;
 
 namespace ed::space_node {
-
-static eAssetImportMethod node_group_asset_import_method(const bContext &C)
-{
-  const SpaceNode *snode = CTX_wm_space_node(&C);
-  return snode != nullptr ? node_group_asset_import_method(*snode) : ASSET_IMPORT_APPEND;
-}
 
 struct LinkDragSearchStorage {
   bNode &from_node;
@@ -218,10 +211,8 @@ static void search_link_ops_for_asset_metadata(const bNodeTree &node_tree,
          [&asset, &socket_property, in_out](nodes::LinkSearchOpParams &params) {
            Main &bmain = *CTX_data_main(&params.C);
 
-           /* Match add-menu behavior: NPR tree assets reuse their local datablock, while other
-            * node editors still append a fresh editable copy. */
            bNodeTree *group = reinterpret_cast<bNodeTree *>(asset::asset_local_id_ensure_imported(
-               bmain, asset, 0, node_group_asset_import_method(params.C)));
+               bmain, asset, 0, node_group_asset_import_method(asset)));
            if (!group) {
              return;
            }

--- a/source/blender/editors/space_node/node_add.cc
+++ b/source/blender/editors/space_node/node_add.cc
@@ -8,6 +8,7 @@
 
 #include <numeric>
 
+#include "AS_asset_library.hh"
 #include "AS_asset_representation.hh"
 
 #include "MEM_guardedalloc.h"
@@ -77,34 +78,26 @@ namespace blender::ed::space_node {
 /** \name Utilities
  * \{ */
 
-static bool is_npr_root_tree(const bNodeTree &node_tree)
+static bool is_builtin_npr_group_asset(const asset_system::AssetRepresentation &asset)
 {
-  for (const bNode *node = static_cast<const bNode *>(node_tree.nodes.first); node != nullptr;
-       node = node->next)
-  {
-    if (STREQ(node->idname, "ShaderNodeNPR_Output")) {
-      return true;
-    }
-  }
-  return false;
-}
-
-static bool node_space_uses_npr_tree(const SpaceNode &snode)
-{
-  SpaceNode &mutable_snode = const_cast<SpaceNode &>(snode);
-  if (!ED_node_is_shader(&mutable_snode)) {
+  if (asset.owner_asset_library().library_type() != ASSET_LIBRARY_ESSENTIALS) {
     return false;
   }
-  if (snode.shaderfrom == SNODE_SHADER_NPR) {
-    return true;
-  }
-  const bNodeTree *root_tree = snode.nodetree ? snode.nodetree : snode.edittree;
-  return root_tree != nullptr && is_npr_root_tree(*root_tree);
+
+  static const asset_system::CatalogID npr_groups_catalog_id(
+      "ee51ee5f-d28f-4de4-8881-54dbd865436e");
+  return asset.get_metadata().catalog_id == npr_groups_catalog_id;
 }
 
-eAssetImportMethod node_group_asset_import_method(const SpaceNode &snode)
+std::optional<eAssetImportMethod> node_group_asset_import_method(
+    const asset_system::AssetRepresentation &asset)
 {
-  return node_space_uses_npr_tree(snode) ? ASSET_IMPORT_APPEND_REUSE : ASSET_IMPORT_APPEND;
+  /* Keep the built-in NPR group bundle reusable, but do not override import behavior for other
+   * asset libraries. This preserves Link libraries and avoids appending duplicate `.001` groups. */
+  if (is_builtin_npr_group_asset(asset)) {
+    return ASSET_IMPORT_APPEND_REUSE;
+  }
+  return std::nullopt;
 }
 
 static void position_node_based_on_mouse(bNode &node, const float2 &location)
@@ -508,10 +501,8 @@ static bool add_node_group_asset(const bContext &C,
   SpaceNode &snode = *CTX_wm_space_node(&C);
   bNodeTree &edit_tree = *snode.edittree;
 
-  /* NPR tree group assets should reuse the first imported datablock so repeated adds keep
-   * referencing the same editable node group. Other node editors still append a fresh copy. */
   bNodeTree *node_group = reinterpret_cast<bNodeTree *>(asset::asset_local_id_ensure_imported(
-      bmain, asset, 0, node_group_asset_import_method(snode)));
+      bmain, asset, 0, node_group_asset_import_method(asset)));
   if (!node_group) {
     return false;
   }
@@ -600,7 +591,7 @@ static wmOperatorStatus node_swap_group_asset_invoke(bContext *C,
   }
   bNodeTree *node_group = reinterpret_cast<bNodeTree *>(
       asset::asset_local_id_ensure_imported(
-          bmain, *asset, 0, node_group_asset_import_method(snode)));
+          bmain, *asset, 0, node_group_asset_import_method(*asset)));
   if (!node_group) {
     return OPERATOR_CANCELLED;
   }

--- a/source/blender/editors/space_node/node_intern.hh
+++ b/source/blender/editors/space_node/node_intern.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "BLI_compute_context.hh"
 #include "BLI_enum_flags.hh"
 #include "BLI_vector.hh"
@@ -41,6 +43,9 @@ extern const char *node_context_dir[];
 
 namespace ed::asset {
 struct AssetItemTree;
+}
+namespace asset_system {
+class AssetRepresentation;
 }
 
 /**
@@ -435,7 +440,8 @@ void draw_nodespace_back_pix(const bContext &C,
 
 bNode *add_node(const bContext &C, StringRef idname, const float2 &location);
 bNode *add_static_node(const bContext &C, int type, const float2 &location);
-eAssetImportMethod node_group_asset_import_method(const SpaceNode &snode);
+std::optional<eAssetImportMethod> node_group_asset_import_method(
+    const asset_system::AssetRepresentation &asset);
 
 void NODE_OT_add_reroute(wmOperatorType *ot);
 void NODE_OT_add_group(wmOperatorType *ot);

--- a/source/blender/editors/space_node/space_node.cc
+++ b/source/blender/editors/space_node/space_node.cc
@@ -1009,12 +1009,14 @@ static bool node_group_drop_poll(bContext *C, wmDrag *drag, const wmEvent * /*ev
 static ID *node_group_drag_id_get_or_import(bContext *C, wmDrag *drag)
 {
   if (drag->type == WM_DRAG_ASSET) {
-    SpaceNode *snode = CTX_wm_space_node(C);
     wmDragAsset *asset_data = WM_drag_get_asset_data(drag, ID_NT);
-    if (snode && asset_data && node_group_asset_import_method(*snode) == ASSET_IMPORT_APPEND_REUSE)
-    {
-      return asset::asset_local_id_ensure_imported(
-          *CTX_data_main(C), *asset_data->asset, 0, ASSET_IMPORT_APPEND_REUSE);
+    if (asset_data) {
+      if (const std::optional<eAssetImportMethod> import_method =
+              node_group_asset_import_method(*asset_data->asset))
+      {
+        return asset::asset_local_id_ensure_imported(
+            *CTX_data_main(C), *asset_data->asset, 0, *import_method);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- only force `APPEND_REUSE` for the built-in `NPR Groups` essentials assets
- preserve the asset library import method for all other node group assets
- apply the same import behavior to add-menu, drag-and-drop, and link-drag search

## Problem

Adding built-in `NPR Groups` assets like `Cavity` repeatedly created duplicate local datablocks such as `Cavity.001` instead of reusing the existing group.

At the same time, node group assets coming from Asset Libraries configured as `Link` were imported as local copies because the node editor overrode the library import method.

## Fix

Detect the built-in `NPR Groups` assets by their essentials catalog and only override those assets to use `APPEND_REUSE`.

For all other node group assets, keep the library-defined import behavior unchanged.

## Validation

- built Blender successfully on Windows
- manually verified that repeatedly adding `Cavity` reuses the same datablock
- manually verified that node group assets from `Link`-configured Asset Libraries are linked instead of appended
