### PR TITLE
fix: avoid duplicate EEVEE resources

### DIFF
--- a/source/blender/draw/engines/eevee/eevee_pipeline.cc
+++ b/source/blender/draw/engines/eevee/eevee_pipeline.cc
@@ -1461,8 +1461,10 @@ template<typename F> void DeferredLayerBase::npr_pass_sync(Instance &inst, F cal
   npr_ps_.bind_texture(SCENE_SHADOW_TEX_SLOT, &inst.pipelines.shadow_filter.texture_ref());
   npr_ps_.bind_image(RBUFS_COLOR_SLOT, &inst.render_buffers.rp_color_tx);
   npr_ps_.bind_image(RBUFS_VALUE_SLOT, &inst.render_buffers.rp_value_tx);
-  npr_aov_color_input_tx_ = inst.render_buffers.rp_color_tx;
-  npr_aov_value_input_tx_ = inst.render_buffers.rp_value_tx;
+  /* Render buffers may not be allocated yet during probe pipeline sync. The concrete inputs are
+   * assigned immediately before each NPR pass is rendered. */
+  npr_aov_color_input_tx_ = nullptr;
+  npr_aov_value_input_tx_ = nullptr;
   npr_ps_.bind_texture(NPR_AOV_COLOR_TEX_SLOT, &npr_aov_color_input_tx_);
   npr_ps_.bind_texture(NPR_AOV_VALUE_TEX_SLOT, &npr_aov_value_input_tx_);
   npr_ps_.bind_image(OUTLINE_COLOR_SLOT, &inst.render_buffers.outline_color_tx);

--- a/source/blender/draw/engines/eevee/eevee_pipeline.cc
+++ b/source/blender/draw/engines/eevee/eevee_pipeline.cc
@@ -138,6 +138,13 @@ static bool material_needs_front_light_shader_resources(const GPUMaterial *gpuma
          GPU_material_flag_get(gpumat, GPU_MATFLAG_GLSL_LIGHT_ACCESS);
 }
 
+static bool material_uses_hybrid_pipeline(const GPUMaterial *gpumat)
+{
+  return GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_TO_RGBA) ||
+         GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_INFO) ||
+         GPU_material_has_glsl_light_shader_eval(gpumat);
+}
+
 static bool material_needs_lightprobe_resources(const GPUMaterial *gpumat)
 {
   return GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_INFO) ||
@@ -1864,10 +1871,11 @@ PassMain::Sub *DeferredLayer::material_add(blender::Material *blender_mat, GPUMa
 
   const bool needs_front_light_shader = material_needs_front_light_shader_resources(gpumat,
                                                                                    closure_bits);
+  const bool uses_hybrid_pipeline = material_uses_hybrid_pipeline(gpumat);
   if (needs_front_light_shader) {
     inst_.lights.tag_front_light_shader_needed();
   }
-  PassMain::Sub *pass = get_gbuffer_subpass(blender_mat, gpumat);
+  PassMain::Sub *pass = get_gbuffer_subpass(blender_mat, gpumat, uses_hybrid_pipeline);
   PassMain::Sub *material_pass = &pass->sub(GPU_material_get_name(gpumat));
   if (inst_.scene->eevee.use_outline && GPU_material_has_outline_output(gpumat)) {
     material_pass->bind_image(OUTLINE_COLOR_SLOT, &inst_.render_buffers.outline_color_tx);
@@ -2686,11 +2694,13 @@ PassMain::Sub *DeferredProbePipeline::material_add(blender::Material *blender_ma
 
   const bool needs_front_light_shader = material_needs_front_light_shader_resources(gpumat,
                                                                                    closure_bits);
+  const bool uses_hybrid_pipeline = material_uses_hybrid_pipeline(gpumat);
   if (needs_front_light_shader) {
     inst_.lights.tag_front_light_shader_needed();
   }
 
-  PassMain::Sub *pass = opaque_layer_.get_gbuffer_subpass(blender_mat, gpumat);
+  PassMain::Sub *pass = opaque_layer_.get_gbuffer_subpass(
+      blender_mat, gpumat, uses_hybrid_pipeline);
   PassMain::Sub *material_pass = &pass->sub(GPU_material_get_name(gpumat));
   if (needs_front_light_shader) {
     material_pass->bind_resources(inst_.lights);
@@ -2890,11 +2900,12 @@ PassMain::Sub *PlanarProbePipeline::material_add(blender::Material *blender_mat,
 
   const bool needs_front_light_shader = material_needs_front_light_shader_resources(gpumat,
                                                                                    closure_bits);
+  const bool uses_hybrid_pipeline = material_uses_hybrid_pipeline(gpumat);
   if (needs_front_light_shader) {
     inst_.lights.tag_front_light_shader_needed();
   }
 
-  PassMain::Sub *pass = get_gbuffer_subpass(blender_mat, gpumat);
+  PassMain::Sub *pass = get_gbuffer_subpass(blender_mat, gpumat, uses_hybrid_pipeline);
   PassMain::Sub *material_pass = &pass->sub(GPU_material_get_name(gpumat));
   if (needs_front_light_shader) {
     material_pass->bind_resources(inst_.lights);

--- a/source/blender/draw/engines/eevee/eevee_pipeline.hh
+++ b/source/blender/draw/engines/eevee/eevee_pipeline.hh
@@ -378,13 +378,14 @@ struct DeferredLayerBase {
 
   DeferredLayerBase(Instance &inst) : prepass_(inst) {};
 
-  PassMain::Sub *get_gbuffer_subpass(blender::Material *blender_mat, GPUMaterial *gpumat)
+  PassMain::Sub *get_gbuffer_subpass(blender::Material *blender_mat,
+                                     GPUMaterial *gpumat,
+                                     const bool use_hybrid_resources)
   {
-    const bool has_shader_to_rgba = GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_TO_RGBA);
     const bool has_raycast = GPU_material_flag_get(gpumat, GPU_MATFLAG_RAYCAST);
     const int cull_method = material_surface_cull_subpass_index(blender_mat);
 
-    return gbuffer_subpasses_[has_shader_to_rgba][has_raycast][cull_method];
+    return gbuffer_subpasses_[use_hybrid_resources][has_raycast][cull_method];
   }
 
   PassMain npr_ps_ = {"NPR"};

--- a/source/blender/draw/engines/eevee/eevee_shader.cc
+++ b/source/blender/draw/engines/eevee/eevee_shader.cc
@@ -1670,22 +1670,30 @@ void ShaderModule::material_create_info_amend(GPUMaterial *gpumat, GPUCodegenOut
       pipeline_type == MAT_PIPE_BAKE_COLOR ||
       (material_graph_uses_lightprobe_data &&
        ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_DEFERRED_NPR, MAT_PIPE_FORWARD));
-  const bool pipeline_create_info_has_lightprobe_data = pipeline_type == MAT_PIPE_DEFERRED_NPR;
+  const bool pipeline_create_info_has_lightprobe_data = ELEM(
+      pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_DEFERRED_NPR, MAT_PIPE_FORWARD);
+
+  /* Forward and hybrid BSL entry points expose LightEvalIterator, which already contains the
+   * light and shadow resource tables. */
+  const bool has_bsl_light_eval_resources =
+      pipeline_type == MAT_PIPE_FORWARD ||
+      (pipeline_type == MAT_PIPE_DEFERRED && use_shader_to_rgba);
 
   const bool use_front_light_shader_in_surface_pass =
       use_shader_to_rgba || surface_graph_uses_glsl_light_access || surface_pass_uses_shader_info;
 
-  if (ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_FORWARD) &&
+  const bool has_bsl_previous_layer_resources =
+      ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_FORWARD) &&
       GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_TO_RGBA) &&
-      GPU_material_flag_get(gpumat, GPU_MATFLAG_TRANSPARENT))
-  {
+      GPU_material_flag_get(gpumat, GPU_MATFLAG_TRANSPARENT);
+  if (has_bsl_previous_layer_resources) {
     info.additional_info("eevee_PreviousLayerHiZ");
     info.additional_info("eevee_PreviousLayerRadiance");
   }
 
-  if (ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_FORWARD) &&
-      !ELEM(geometry_type, MAT_GEOM_WORLD, MAT_GEOM_VOLUME))
-  {
+  const bool has_bsl_hiz_resource = ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_FORWARD) &&
+                                    !ELEM(geometry_type, MAT_GEOM_WORLD, MAT_GEOM_VOLUME);
+  if (has_bsl_hiz_resource) {
     /* While only needed for the AO node, bind HiZ before allocating user resource slots. */
     info.additional_info("eevee_HiZ");
   }
@@ -1732,7 +1740,7 @@ void ShaderModule::material_create_info_amend(GPUMaterial *gpumat, GPUCodegenOut
     }
   }
 
-  if (use_hiz_data) {
+  if (use_hiz_data && !has_bsl_hiz_resource) {
     add_create_info_and_reserve(info, slots, "eevee_hiz_data");
   }
   if (use_raycast) {
@@ -1794,28 +1802,36 @@ void ShaderModule::material_create_info_amend(GPUMaterial *gpumat, GPUCodegenOut
   }
 
   if (ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_FORWARD) &&
-      (use_shader_to_rgba || GPU_material_flag_get(gpumat, GPU_MATFLAG_SCREENSPACE_INFO)))
+      (use_shader_to_rgba || GPU_material_flag_get(gpumat, GPU_MATFLAG_SCREENSPACE_INFO)) &&
+      !has_bsl_previous_layer_resources)
   {
     add_create_info_and_reserve(info, slots, "eevee_hiz_prev_data");
     add_create_info_and_reserve(info, slots, "eevee_previous_layer_radiance");
   }
 
-  if ((GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_INFO) ||
+  const bool has_shader_info_light_resources =
+      (GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_INFO) ||
        GPU_material_flag_get(gpumat, GPU_MATFLAG_NPR_FOREACH_LIGHT)) &&
       ELEM(pipeline_type,
            MAT_PIPE_DEFERRED,
            MAT_PIPE_DEFERRED_NPR,
            MAT_PIPE_FORWARD,
-           MAT_PIPE_BAKE_COLOR))
-  {
-    add_create_info_and_reserve(info, slots, "eevee_light_data");
+           MAT_PIPE_BAKE_COLOR);
+  if (has_shader_info_light_resources) {
+    if (!has_bsl_light_eval_resources) {
+      add_create_info_and_reserve(info, slots, "eevee_light_data");
+    }
     if (GPU_material_flag_get(gpumat, GPU_MATFLAG_SHADER_INFO)) {
       info.define("CREATE_INFO_eevee_LightRenderData");
     }
-    add_create_info_and_reserve(info, slots, "eevee_shadow_data");
+    if (!has_bsl_light_eval_resources) {
+      add_create_info_and_reserve(info, slots, "eevee_shadow_data");
+    }
     if (use_shader_info_shadow_classification) {
       info.define("SHADOW_CASTER_CLASSIFY");
-      add_create_info_and_reserve(info, slots, "eevee_shadow_caster_data");
+      if (!has_bsl_light_eval_resources) {
+        add_create_info_and_reserve(info, slots, "eevee_shadow_caster_data");
+      }
     }
   }
   if (pipeline_type == MAT_PIPE_BAKE_COLOR) {
@@ -1826,10 +1842,14 @@ void ShaderModule::material_create_info_amend(GPUMaterial *gpumat, GPUCodegenOut
     if (depth_offset_uses_light_access && pipeline_type != MAT_PIPE_BAKE_COLOR) {
       info.define("LIGHT_ITER_FORCE_NO_CULLING");
     }
-    add_create_info_and_reserve(info, slots, "eevee_light_data");
+    if (!has_shader_info_light_resources && !has_bsl_light_eval_resources) {
+      add_create_info_and_reserve(info, slots, "eevee_light_data");
+    }
     if (material_pass_uses_glsl_light_access) {
       info.define("MAT_GLSL_LIGHT_SHADOW_ACCESS");
-      add_create_info_and_reserve(info, slots, "eevee_shadow_data");
+      if (!has_shader_info_light_resources && !has_bsl_light_eval_resources) {
+        add_create_info_and_reserve(info, slots, "eevee_shadow_data");
+      }
     }
     if (surface_pass_uses_glsl_light_access) {
       info.define("MAT_GLSL_LIGHT_SHADER_EVAL");

--- a/source/blender/draw/engines/eevee/eevee_shader.cc
+++ b/source/blender/draw/engines/eevee/eevee_shader.cc
@@ -1673,14 +1673,14 @@ void ShaderModule::material_create_info_amend(GPUMaterial *gpumat, GPUCodegenOut
   const bool pipeline_create_info_has_lightprobe_data = ELEM(
       pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_DEFERRED_NPR, MAT_PIPE_FORWARD);
 
+  const bool use_front_light_shader_in_surface_pass =
+      use_shader_to_rgba || surface_graph_uses_glsl_light_access || surface_pass_uses_shader_info;
+
   /* Forward and hybrid BSL entry points expose LightEvalIterator, which already contains the
    * light and shadow resource tables. */
   const bool has_bsl_light_eval_resources =
       pipeline_type == MAT_PIPE_FORWARD ||
-      (pipeline_type == MAT_PIPE_DEFERRED && use_shader_to_rgba);
-
-  const bool use_front_light_shader_in_surface_pass =
-      use_shader_to_rgba || surface_graph_uses_glsl_light_access || surface_pass_uses_shader_info;
+      (pipeline_type == MAT_PIPE_DEFERRED && use_front_light_shader_in_surface_pass);
 
   const bool has_bsl_previous_layer_resources =
       ELEM(pipeline_type, MAT_PIPE_DEFERRED, MAT_PIPE_FORWARD) &&

--- a/source/blender/draw/engines/eevee/shaders/eevee_surf_deferred.bsl.hh
+++ b/source/blender/draw/engines/eevee/shaders/eevee_surf_deferred.bsl.hh
@@ -45,9 +45,6 @@ namespace eevee {
 struct SurfaceDeferred {
   [[legacy_info]] ShaderCreateInfo draw_view_culling;
   [[legacy_info]] ShaderCreateInfo eevee_geom_iface_info;
-  /* NPR: custom screen-space material nodes (bevel, curvature, ...) sample scene depth directly.
-   * Restores the `hiz_tx` binding that npr-port-5.1 had on the (now removed) legacy deferred base. */
-  [[legacy_info]] ShaderCreateInfo eevee_hiz_data;
 
   /* Everything is stored inside a two layered target, one for each format. This is to fit the
    * limitation of the number of images we can bind on a single shader. */

--- a/source/blender/draw/engines/eevee/shaders/eevee_surf_forward.bsl.hh
+++ b/source/blender/draw/engines/eevee/shaders/eevee_surf_forward.bsl.hh
@@ -94,10 +94,6 @@ struct SurfaceForward {
 
   [[legacy_info]] ShaderCreateInfo draw_view_culling;
 
-  /* NPR: custom screen-space material nodes (bevel, curvature, ...) sample scene depth directly.
-   * Restores the `hiz_tx` binding that npr-port-5.1 had on the (now removed) legacy forward base. */
-  [[legacy_info]] ShaderCreateInfo eevee_hiz_data;
-
   /* Optionally added depending on the material. */
   // [[legacy_info]] ShaderCreateInfo eevee_hiz_prev_data;
   // [[legacy_info]] ShaderCreateInfo eevee_previous_layer_radiance;

--- a/source/blender/draw/engines/eevee/shaders/eevee_surf_hybrid.bsl.hh
+++ b/source/blender/draw/engines/eevee/shaders/eevee_surf_hybrid.bsl.hh
@@ -91,7 +91,6 @@ namespace eevee {
 struct SurfaceHybrid {
   [[legacy_info]] ShaderCreateInfo draw_view_culling;
   [[legacy_info]] ShaderCreateInfo eevee_geom_iface_info;
-  [[legacy_info]] ShaderCreateInfo eevee_hiz_data;
 
   /* Everything is stored inside a two layered target, one for each format. This is to fit the
    * limitation of the number of images we can bind on a single shader. */


### PR DESCRIPTION
最新的 release，在 Linux + Vulkan 的环境下会导致崩溃

## PR Summary

  修复 EEVEE 材质/渲染预览切换时 Vulkan 崩溃及着色器无限编译问题。

  BSL 材质入口已提供 HiZ、previous-layer、light、shadow、shadow-caster、light-probe 资源；动态材质组装仍追加旧 create-info，造成同一 Vulkan descriptor 重复注册。

  改动：

  - 删除 deferred、forward、hybrid 中重复 eevee_hiz_data
  - 避免 BSL 与 legacy HiZ/previous-layer 资源同时加入
  - 避免 hybrid/forward 重复加入 light、shadow、shadow-caster、light-probe 资源
  - NPR AOV 纹理延迟到 render buffers 分配后解析，避免 probe sync 空纹理 assert
  - 保留 NPR、bake、world、volume 所需 legacy 路径
