### PR TITLE
修复灯光着色器和体积散射导致的崩溃

### DIFF
--- a/source/blender/draw/engines/eevee/eevee_light.hh
+++ b/source/blender/draw/engines/eevee/eevee_light.hh
@@ -351,6 +351,20 @@ class LightModule {
     pass.bind_ssbo(LIGHT_SHADER_UNIFORM_BUF_SLOT, &uniform_light_shader_buf_);
   }
 
+  /**
+   * Ensure GPU buffers backing the light shader SSBOs are allocated, even when no lights
+   * with light shaders are present. Required because the volume scatter shader struct
+   * always includes LightShaderEvalData bindings (LIGHT_SHADER_INDEX_BUF_SLOT,
+   * LIGHT_SHADER_UNIFORM_BUF_SLOT). Without this call the VkBuffer handles may remain
+   * unregistered in the resource tracker, causing a crash when the render graph builds
+   * resource links.
+   */
+  void ensure_volume_light_shader_resources_allocated()
+  {
+    volume_light_shader_index_buf_.clear_to_zero();
+    uniform_light_shader_buf_.clear_to_zero();
+  }
+
   template<typename PassType> void bind_surfel_light_shader_resources(PassType &pass)
   {
     pass.bind_ssbo(LIGHT_SHADER_SURFEL_INDEX_BUF_SLOT, &surfel_light_shader_index_buf_);

--- a/source/blender/draw/engines/eevee/eevee_volume.cc
+++ b/source/blender/draw/engines/eevee/eevee_volume.cc
@@ -283,6 +283,13 @@ void VolumeModule::end_sync()
   const GPUSamplerState history_sampler = {GPU_SAMPLER_FILTERING_LINEAR,
                                            GPU_SAMPLER_EXTEND_MODE_EXTEND,
                                            GPU_SAMPLER_EXTEND_MODE_EXTEND};
+  /* Ensure light shader SSBOs are allocated before binding. The volume scatter shader
+   * struct always includes LightShaderEvalData which references these SSBO slots, even
+   * when no lights with custom light shaders are present. Without pre-allocation the
+   * underlying VkBuffers may not be registered in the resource tracker.
+   */
+  inst_.lights.ensure_volume_light_shader_resources_allocated();
+
   scatter_ps_.init();
   scatter_ps_.shader_set(
       inst_.shaders.static_shader_get(use_lights_ ? VOLUME_SCATTER_WITH_LIGHTS : VOLUME_SCATTER));

--- a/source/blender/draw/engines/eevee/shaders/eevee_light_eval.bsl.hh
+++ b/source/blender/draw/engines/eevee/shaders/eevee_light_eval.bsl.hh
@@ -40,7 +40,7 @@ namespace eevee {
 struct LightEvalData {
   [[resource_table]] srt_t<ShadowRenderData> shadow_data;
   [[resource_table]] srt_t<UtilityTexture> utility_tx;
-  [[resource_table]] srt_t<LightShaderEvalData> light_shader_data;
+  [[resource_table, condition(use_light_shader_texture_eval)]] srt_t<LightShaderEvalData> light_shader_data;
 
   [[compilation_constant]] bool use_light_shader_texture_eval;
   [[compilation_constant]] bool use_light_shader_surfel_eval;

--- a/source/blender/draw/engines/eevee/shaders/eevee_volume.bsl.hh
+++ b/source/blender/draw/engines/eevee/shaders/eevee_volume.bsl.hh
@@ -100,7 +100,7 @@ struct Scatter {
   [[resource_table]] srt_t<draw::View> views_;
   [[resource_table]] srt_t<LightRenderData> light_data;
   [[resource_table]] srt_t<ShadowRenderData> shadow_data;
-  [[resource_table]] srt_t<LightShaderEvalData> light_shader_data;
+  [[resource_table, condition(use_volume_light)]] srt_t<LightShaderEvalData> light_shader_data;
   [[resource_table]] srt_t<LightprobeVolumeRenderData> lightprobe_volume_data;
 
   [[sampler(0)]] sampler3D scattering_history_tx;
@@ -154,30 +154,32 @@ struct LightEvalCtx {
 
     float attenuation = light_attenuation_volume(light, is_directional, lv);
     bool use_light_shader_no_distance = false;
-    [[resource_table]] const LightShaderEvalData &light_shader_data = srt.light_shader_data;
-    int light_shader_index = light_shader_data.light_shader_index_buf[l_idx];
-    int light_shader_uniform_index = (light_shader_index < -1) ? -light_shader_index - 2 : -1;
-    if (light_shader_uniform_index >= 0) {
-      float4 light_shader = light_shader_data.light_shader_uniform_buf[light_shader_uniform_index];
-      light.color = light_shader.rgb;
-      attenuation = light_attenuation_common(light, is_directional, lv.L) * light_shader.a;
-      use_light_shader_no_distance = true;
-      if (!is_directional) {
-        attenuation *= light_influence_cutoff(lv.dist,
-                                              light.local().local.influence_radius_invsqr_volume);
+    if (srt.use_volume_light) [[static_branch]] {
+      [[resource_table]] const LightShaderEvalData &light_shader_data = srt.light_shader_data;
+      int light_shader_index = light_shader_data.light_shader_index_buf[l_idx];
+      int light_shader_uniform_index = (light_shader_index < -1) ? -light_shader_index - 2 : -1;
+      if (light_shader_uniform_index >= 0) {
+        float4 light_shader = light_shader_data.light_shader_uniform_buf[light_shader_uniform_index];
+        light.color = light_shader.rgb;
+        attenuation = light_attenuation_common(light, is_directional, lv.L) * light_shader.a;
+        use_light_shader_no_distance = true;
+        if (!is_directional) {
+          attenuation *= light_influence_cutoff(lv.dist,
+                                                light.local().local.influence_radius_invsqr_volume);
+        }
       }
-    }
-    else if (light_shader_index >= 0) {
-      int layer = light_shader_index * uni.uniform_buf.volumes.tex_size.z + froxel.z;
-      float4 light_shader = texelFetch(light_shader_data.light_shader_tx,
-                                       int3(froxel.xy, layer),
-                                       0);
-      light.color = light_shader.rgb;
-      attenuation = light_attenuation_common(light, is_directional, lv.L) * light_shader.a;
-      use_light_shader_no_distance = true;
-      if (!is_directional) {
-        attenuation *= light_influence_cutoff(lv.dist,
-                                              light.local().local.influence_radius_invsqr_volume);
+      else if (light_shader_index >= 0) {
+        int layer = light_shader_index * uni.uniform_buf.volumes.tex_size.z + froxel.z;
+        float4 light_shader = texelFetch(light_shader_data.light_shader_tx,
+                                         int3(froxel.xy, layer),
+                                         0);
+        light.color = light_shader.rgb;
+        attenuation = light_attenuation_common(light, is_directional, lv.L) * light_shader.a;
+        use_light_shader_no_distance = true;
+        if (!is_directional) {
+          attenuation *= light_influence_cutoff(lv.dist,
+                                                light.local().local.influence_radius_invsqr_volume);
+        }
       }
     }
     if (attenuation < LIGHT_ATTENUATION_THRESHOLD) {


### PR DESCRIPTION
修复前：
  Scatter 无条件包含 LightShaderEvalData
    → VOLUME_SCATTER 也声明 slot 5,13,20
    → use_lights_=false 时不绑定这些 SSBO
    → compute_dispatch 时 state_manager.get(5) 越界 → 崩溃

修复后：
  [[resource_table, condition(use_volume_light)]]
    → VOLUME_SCATTER (use_volume_light=false) 不声明 slot 5,13,20
    → 着色器接口中无这些绑定 → update_resource_access_info 不访问
    → VOLUME_SCATTER_WITH_LIGHTS (use_volume_light=true) 正常工作

详见注释